### PR TITLE
🐛 Avoid sending empty state_code for countries that do not need it

### DIFF
--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -223,7 +223,7 @@ function createShipmentForOrder($orderId)
         ->setEmail($orderData['billing']['email'])
         ->setPhoneNumber($orderData['billing']['phone']);
 
-    if (is_string($orderData['shipping']['state']) && strlen($orderData['shipping']['state']) <= 3) {
+    if (isset($orderData['shipping']['state']) && preg_match('/^[A-Z\d]{1,3}$/', $orderData['shipping']['state'])) {
         $recipient->setStateCode($orderData['shipping']['state']);
     }
 


### PR DESCRIPTION
Only send the value when it matches the regex of our API.