### PR TITLE
♿️ Migrate existing config + support existing orders with shipments

### DIFF
--- a/assets/admin/js/setting-page.js
+++ b/assets/admin/js/setting-page.js
@@ -1,24 +1,24 @@
 jQuery(function ($) {
   $('#myparcelcom-settings-form').validate({
     rules: {
-      client_key: {
+      myparcelcom_client_id: {
         required: true
       },
-      client_secret_key: {
+      myparcelcom_client_secret: {
         required: true
       },
-      myparcel_shopid: {
+      myparcelcom_shop_id: {
         required: true
       }
     },
     messages: {
-      client_key: {
+      myparcelcom_client_id: {
         required: 'Required'
       },
-      client_secret_key: {
+      myparcelcom_client_secret: {
         required: 'Required'
       },
-      myparcel_shopid: {
+      myparcelcom_shop_id: {
         required: 'Required'
       }
     },
@@ -35,12 +35,12 @@ jQuery(function ($) {
     },
   })
 
-  const shopSelect = $('#myparcel_shopid')
+  const shopSelect = $('#myparcelcom_shop_id')
 
   function resetShopList () {
-    const id = $('#client_key').val()
-    const secret = $('#client_secret_key').val()
-    const testmode = $('#act_test_mode').prop('checked') ? '1' : '0'
+    const id = $('#myparcelcom_client_id').val()
+    const secret = $('#myparcelcom_client_secret').val()
+    const testmode = $('#myparcelcom_test_mode').prop('checked') ? '1' : '0'
 
     if (id && secret) {
       shopSelect.empty().append($('<option>', {
@@ -50,9 +50,9 @@ jQuery(function ($) {
 
       const data = {
         action: 'myparcelcom_get_shops_for_client',
-        client_key: id,
-        client_secret_key: secret,
-        act_test_mode: testmode
+        myparcelcom_client_id: id,
+        myparcelcom_client_secret: secret,
+        myparcelcom_test_mode: testmode
       }
       jQuery.post(ajaxurl, data, function (response) {
         const shops = JSON.parse(response)
@@ -79,7 +79,7 @@ jQuery(function ($) {
     }
   }
 
-  $('#act_test_mode, #client_key, #client_secret_key').change(function () {
+  $('#myparcelcom_test_mode, #myparcelcom_client_id, #myparcelcom_client_secret').change(function () {
     resetShopList()
   })
   resetShopList()

--- a/composer.lock
+++ b/composer.lock
@@ -396,16 +396,16 @@
         },
         {
             "name": "myparcelcom/api-sdk",
-            "version": "v3.2.1",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MyParcelCOM/api-sdk-php.git",
-                "reference": "522cbbd9dd5d317f0d5f0d33ac53215288fb0e52"
+                "reference": "303bf640873351b0e326e13b575df7f18de0656e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MyParcelCOM/api-sdk-php/zipball/522cbbd9dd5d317f0d5f0d33ac53215288fb0e52",
-                "reference": "522cbbd9dd5d317f0d5f0d33ac53215288fb0e52",
+                "url": "https://api.github.com/repos/MyParcelCOM/api-sdk-php/zipball/303bf640873351b0e326e13b575df7f18de0656e",
+                "reference": "303bf640873351b0e326e13b575df7f18de0656e",
                 "shasum": ""
             },
             "require": {
@@ -440,9 +440,9 @@
             "description": "Package for communicating with the MyParcel.com API.",
             "support": {
                 "issues": "https://github.com/MyParcelCOM/api-sdk-php/issues",
-                "source": "https://github.com/MyParcelCOM/api-sdk-php/tree/v3.2.1"
+                "source": "https://github.com/MyParcelCOM/api-sdk-php/tree/v3.2.2"
             },
-            "time": "2024-03-07T13:11:40+00:00"
+            "time": "2024-06-25T14:20:15+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -1620,12 +1620,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "601ba5186e85dff8a3cc1feabe69e1a11805d9b2"
+                "reference": "27714b56f04815b654c3805502ab77207505ac19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/601ba5186e85dff8a3cc1feabe69e1a11805d9b2",
-                "reference": "601ba5186e85dff8a3cc1feabe69e1a11805d9b2",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/27714b56f04815b654c3805502ab77207505ac19",
+                "reference": "27714b56f04815b654c3805502ab77207505ac19",
                 "shasum": ""
             },
             "conflict": {
@@ -1633,7 +1633,7 @@
                 "admidio/admidio": "<4.2.13",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<2.2",
-                "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.21|>=2022.04.1,<2022.10.12|>=2023.04.1,<2023.10.14|>=2024.04.1,<2024.04.4",
+                "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
                 "airesvsg/acf-to-rest-api": "<=3.1",
@@ -2016,7 +2016,7 @@
                 "october/cms": "<1.0.469|==1.0.469|==1.0.471|==1.1.1",
                 "october/october": "<=3.4.4",
                 "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.34|>=3,<3.5.2",
+                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.34|>=3,<3.5.15",
                 "omeka/omeka-s": "<4.0.3",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
@@ -2417,7 +2417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-24T21:04:21+00:00"
+            "time": "2024-06-26T15:05:17+00:00"
         }
     ],
     "aliases": [],

--- a/includes/common/myparcel-constant.php
+++ b/includes/common/myparcel-constant.php
@@ -1,11 +1,18 @@
 <?php
 
+const MYPARCEL_CLIENT_ID = 'myparcelcom_client_id';
+const MYPARCEL_CLIENT_SECRET = 'myparcelcom_client_secret';
 const MYPARCEL_SHIPMENT_ID = 'myparcelcom_shipment_id';
 const MYPARCEL_SHIPMENT_DATA = 'myparcelcom_shipment_data';
-const MYPARCEL_SHOP_ID = 'myparcel_shopid';
+const MYPARCEL_SHOP_ID = 'myparcelcom_shop_id';
+const MYPARCEL_TEST_MODE = 'myparcelcom_test_mode';
 const MYPARCEL_WEBHOOK_ID = 'myparcelcom_webhook_id';
 const MYPARCEL_WEBHOOK_SECRET = 'myparcelcom_webhook_secret';
 
 // Legacy constants used in v2 and v1 versions of this plugin.
+const MYPARCEL_LEGACY_CLIENT_KEY = 'client_key';
+const MYPARCEL_LEGACY_CLIENT_SECRET = 'client_secret_key';
+const MYPARCEL_LEGACY_TEST_MODE = 'act_test_mode';
+const MYPARCEL_LEGACY_SHOP_ID = 'myparcel_shopid';
 const MYPARCEL_LEGACY_SHIPMENT_ID = 'trackingKey';
 const MYPARCEL_LEGACY_SHIPMENT_META = 'shipment_track_key';

--- a/includes/myparcel-api.php
+++ b/includes/myparcel-api.php
@@ -18,13 +18,13 @@ class MyParcelApi extends MyParcelComApi
 
     public static function createSingletonFromConfig(array $config = null): MyParcelComApi
     {
-        $testMode = $config ? $config['act_test_mode'] : get_option('act_test_mode');
+        $testMode = $config ? $config[MYPARCEL_TEST_MODE] : get_option(MYPARCEL_TEST_MODE);
         $apiUrl = $testMode ? self::SANDBOX_API_URL : self::PRODUCTION_API_URL;
         $authUrl = $testMode ? self::SANDBOX_AUTH_URL : self::PRODUCTION_AUTH_URL;
 
         $authenticator = new ClientCredentials(
-            $config ? $config['client_key'] : (string) get_option('client_key'),
-            $config ? $config['client_secret_key'] : (string) get_option('client_secret_key'),
+            $config ? $config[MYPARCEL_CLIENT_ID] : (string) get_option(MYPARCEL_CLIENT_ID),
+            $config ? $config[MYPARCEL_CLIENT_SECRET] : (string) get_option(MYPARCEL_CLIENT_SECRET),
             $authUrl,
         );
 

--- a/includes/myparcel-settings.php
+++ b/includes/myparcel-settings.php
@@ -50,7 +50,7 @@ function registerSettings(): void
 
         add_action('admin_notices', function () {
             echo '<div class="notice notice-success is-dismissible">';
-            echo '<p>MyParcel.com plugin webhooks successfully set up.</p>';
+            echo '<p>MyParcel.com plugin webhook successfully set up.</p>';
             echo '</div>';
         });
     }


### PR DESCRIPTION
- Prefix config values with `myparcelcom_` + migrate existing config if needed.
- Register the webhook automatically after installing the v3.x version.
- To avoid an empty column for existing shipments, fetch them once more + store their status as a webhook response.