### PR TITLE
🔊 Show error detail or title if meta does not have json_schema_errors

### DIFF
--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -217,7 +217,10 @@ function exportPrintBulkActionAdminNotice(): void
                     break;
 
                 case 'shipment_error':
-                    $errorMessages = array_map('htmlspecialchars', $_REQUEST['shipment_error_messages']);
+                    $errorMessages = array_map(
+                        fn (string $message) => htmlspecialchars(stripslashes($message)),
+                        $_REQUEST['shipment_error_messages'], // Already urldecoded.
+                    );
 
                     echo '<div class="notice notice-error is-dismissible"><p>'
                         . implode('<br>', $errorMessages)

--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -163,6 +163,10 @@ function myparcelcomBulkActionHandler(string $redirectTo, string $action, array 
                                         $schemaError['message']
                                     ]);
                                 }
+                            } else if (isset($error['detail'])) {
+                                $errorMessages[] = $error['detail'];
+                            } else if (isset($error['title'])) {
+                                $errorMessages[] = $error['title'];
                             }
                         }
                     }

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Plugin Name: MyParcel.com
  * Plugin URI: https://help.myparcel.com/home/integrations-1#Integrations-WooCommerce
  * Description: This plugin enables you to export WooCommerce orders to MyParcel.com.
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: MyParcel.com
  * Author URI: https://www.myparcel.com
  * Requires at least:


### PR DESCRIPTION
Errors from our api-specification are shown properly, but additional validation done by our API does not output a `meta`. This makes the notification very generic, so we should print the `detail` or the `title` of the error to make it more clear.

An example of API validation details shown as a second line:
![Screenshot from 2024-07-15 17-10-55](https://github.com/user-attachments/assets/381eefcb-6f17-4ea4-8bb6-fe38454b1d44)
