### PR TITLE
🧟 Keep legacy options to support cached admin pages

### DIFF
--- a/includes/myparcel-settings.php
+++ b/includes/myparcel-settings.php
@@ -26,16 +26,13 @@ add_action('admin_enqueue_scripts', 'settingPageJsCss', 999);
 function registerSettings(): void
 {
     // Migrate old settings to the new prefixed values (we check for "act_test_mode" because that option was always set)
-    if (get_option(MYPARCEL_LEGACY_TEST_MODE) !== false) {
+    if (get_option(MYPARCEL_TEST_MODE) === false && get_option(MYPARCEL_LEGACY_TEST_MODE) !== false) {
         update_option(MYPARCEL_CLIENT_ID, get_option(MYPARCEL_LEGACY_CLIENT_KEY));
         update_option(MYPARCEL_CLIENT_SECRET, get_option(MYPARCEL_LEGACY_CLIENT_SECRET));
         update_option(MYPARCEL_TEST_MODE, get_option(MYPARCEL_LEGACY_TEST_MODE));
         update_option(MYPARCEL_SHOP_ID, get_option(MYPARCEL_LEGACY_SHOP_ID));
 
-        delete_option(MYPARCEL_LEGACY_CLIENT_KEY);
-        delete_option(MYPARCEL_LEGACY_CLIENT_SECRET);
-        delete_option(MYPARCEL_LEGACY_TEST_MODE);
-        delete_option(MYPARCEL_LEGACY_SHOP_ID);
+        // NOTE: do not delete the legacy options, since customers with cache plugins experienced a crash after install.
 
         add_action('admin_notices', function () {
             echo '<div class="notice notice-success is-dismissible">';

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Plugin Name: MyParcel.com
  * Plugin URI: https://help.myparcel.com/home/integrations-1#Integrations-WooCommerce
  * Description: This plugin enables you to export WooCommerce orders to MyParcel.com.
- * Version: 3.0.1
+ * Version: 3.0.2
  * Author: MyParcel.com
  * Author URI: https://www.myparcel.com
  * Requires at least:


### PR DESCRIPTION
WP installations that have all plugin code cached are running into an issue when it needs the legacy config values.