### PR TITLE
Add HPOS compatibility

### DIFF
--- a/includes/common/common-functions.php
+++ b/includes/common/common-functions.php
@@ -13,10 +13,9 @@ use MyParcelCom\ApiSdk\Resources\ShipmentItem;
 use MyParcelCom\ApiSdk\Resources\Shop;
 
 /**
- * @param $orderId
  * @return WC_Order_Item[]
  */
-function getOrderItems($orderId)
+function getOrderItemsByOrderId(int $orderId): array
 {
     $order = wc_get_order($orderId);
 
@@ -24,12 +23,12 @@ function getOrderItems($orderId)
 }
 
 /**
- * @param int $postId
- * @return float|int
+ * @param int $orderId
+ * @return float
  */
-function getTotalWeightByPostID($postId)
+function getTotalWeightByOrderID(int $orderId): float
 {
-    $items = getOrderItems($postId);
+    $items = getOrderItemsByOrderId($orderId);
     $totalWeight = 0;
 
     foreach ($items as $item) {
@@ -44,9 +43,10 @@ function getTotalWeightByPostID($postId)
 /**
  * @return ShipmentItem[]
  */
-function getShipmentItems($orderId, $currency, $originCountryCode)
+function getShipmentItems($orderId, $currency, $originCountryCode): array
 {
-    $items = getOrderItems($orderId);
+    $order = wc_get_order($orderId);
+    $items = getOrderItemsByOrderId($orderId);
     $shipmentItems = [];
 
     foreach ($items as $item) {
@@ -55,8 +55,8 @@ function getShipmentItems($orderId, $currency, $originCountryCode)
         $imageUrl = $product->get_image_id() ? wp_get_attachment_image_url($product->get_image_id(), 'medium') : null;
         $itemValue = (int) round(floatval($product->get_price()) * 100);
         $itemWeight = $product->get_weight() ? (int) round(floatval($product->get_weight()) * 1000) : null;
-        $hsCode = get_post_meta($product->get_id(), 'myparcel_hs_code', true) ?: null;
-        $productCountry = get_post_meta($product->get_id(), 'myparcel_product_country', true);
+        $hsCode = $order->get_meta('myparcel_hs_code') ?: null;
+        $productCountry = $order->get_meta('myparcel_product_country');
 
         $shipmentItems[] = (new ShipmentItem())
             ->setSku($sku)
@@ -162,11 +162,12 @@ function downloadPdf(): void
     $shipments         = [];
 
     foreach ($orderIds as $orderId) {
-        $shipmentId = get_post_meta($orderId, MYPARCEL_SHIPMENT_ID, true);
+        $order = wc_get_order($orderId);
+        $shipmentId =  $order->get_meta(MYPARCEL_SHIPMENT_ID);
 
         // If no shipment ID is found, we check the legacy meta, which is used by our v2.x plugin.
         if (empty($shipmentId)) {
-            $legacyMeta = get_post_meta($orderId, MYPARCEL_LEGACY_SHIPMENT_META, true);
+            $legacyMeta = $order->get_meta(MYPARCEL_LEGACY_SHIPMENT_META);
             if (!empty($legacyMeta)) {
                 $legacyData = json_decode($legacyMeta, true);
                 $shipmentId = $legacyData[MYPARCEL_LEGACY_SHIPMENT_ID];

--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -52,13 +52,14 @@ add_filter('manage_edit-shop_order_columns', 'customShopOrderColumn', 11);
  */
 function customOrdersListColumnContent(string $column, int $orderId): void
 {
+    $order = wc_get_order($orderId);
     switch ($column) {
         case 'myparcelcom_shipment_status':
-            $shipmentData = get_post_meta($orderId, MYPARCEL_SHIPMENT_DATA, true);
+            $shipmentData = $order->get_meta(MYPARCEL_SHIPMENT_DATA);
 
             // If no shipment data is found, we check the legacy meta, which is used by our v2.x plugin.
             if (empty($shipmentData)) {
-                $legacyMeta = get_post_meta($orderId, MYPARCEL_LEGACY_SHIPMENT_META, true);
+                $legacyMeta = $order->get_meta(MYPARCEL_LEGACY_SHIPMENT_META);
                 if (!empty($legacyMeta)) {
                     $legacyData = json_decode($legacyMeta, true);
                     $shipmentId = $legacyData[MYPARCEL_LEGACY_SHIPMENT_ID];
@@ -69,8 +70,8 @@ function customOrdersListColumnContent(string $column, int $orderId): void
                         $api = MyParcelApi::createSingletonFromConfig();
                         $shipment = $api->getShipment($shipmentId);
 
-                        update_post_meta($orderId, MYPARCEL_SHIPMENT_ID, $shipment->getId());
-                        update_post_meta($orderId, MYPARCEL_SHIPMENT_DATA, json_encode([
+                        $order->update_meta_data(MYPARCEL_SHIPMENT_ID, $shipment->getId());
+                        $order->update_meta_data(MYPARCEL_SHIPMENT_DATA, json_encode([
                             'status_code'   => $shipment->getShipmentStatus()->getStatus()->getCode(),
                             'status_name'   => $shipment->getShipmentStatus()->getStatus()->getName(),
                             'tracking_code' => $shipment->getTrackingCode(),
@@ -246,7 +247,7 @@ add_action('admin_notices', 'exportPrintBulkActionAdminNotice');
 function createShipmentForOrder(int $orderId): ShipmentInterface
 {
     $pluginData     = get_plugin_data(plugin_dir_path(__FILE__) . '../woocommerce-connect-myparcel.php', false, false);
-    $totalWeight    = getTotalWeightByPostID($orderId) * 1000;
+    $totalWeight    = getTotalWeightByOrderID($orderId) * 1000;
     $countAllWeight = max($totalWeight, 1000);
     $order          = wc_get_order($orderId);
     $orderData      = $order->get_data();
@@ -356,7 +357,7 @@ function isEUCountry(string $countryCode): bool
 /**
  * Add meta box input fields on the right side of the "product" edit page.
  */
-function addMyparcelcomProductMeta(WP_Post $post): void
+function addMyparcelcomProductMeta(WC_Order|WP_Post $object): void
 {
     add_meta_box('product_country', 'Country Of Origin', 'renderCountryOfOriginInput', 'product', 'side');
     add_meta_box('product_hs_code', 'HS code', 'renderHsCodeInput', 'product', 'side');
@@ -365,11 +366,25 @@ function addMyparcelcomProductMeta(WP_Post $post): void
 add_action('add_meta_boxes_product', 'addMyparcelcomProductMeta');
 
 /**
+ * Get the order (WC_Order) from the given object. The object can be a WP_Post (WordPress class) or a WC_Order (Woocommerce class).
+ * Src: https://stackoverflow.com/questions/78261367/add-a-custom-metabox-to-woocommerce-admin-orders-with-hpos-enabled
+ * @param WC_Order|WP_Post $arg - the resource to get the order from.
+ * @return WC_Order
+ */
+function getWcOrderFromAddMetaBoxArg(WC_Order|WP_Post $arg): WC_Order
+{
+    return $arg instanceof WP_Post
+        ? wc_get_order($arg->ID)
+        : $arg;
+}
+
+/**
  * Render meta input field for Country Of Origin.
  */
-function renderCountryOfOriginInput(WP_Post $post): void
+function renderCountryOfOriginInput(WC_Order|WP_Post $object): void
 {
-    $value = get_post_meta($post->ID, 'myparcel_product_country', true);
+    $order = getWcOrderFromAddMetaBoxArg($object);
+    $value = $order->get_meta('myparcel_product_country');
     echo '<label for="coo_input">Country Of Origin</label>';
     echo '<input type="text" name="coo_input" id="coo_input" value="' . $value . '">';
 }
@@ -377,20 +392,22 @@ function renderCountryOfOriginInput(WP_Post $post): void
 /**
  * Render meta input field for HS code.
  */
-function renderHsCodeInput(WP_Post $post): void
+function renderHsCodeInput(WC_Order|WP_Post $object): void
 {
-    $value = get_post_meta($post->ID, 'myparcel_hs_code', true);
+    $order = getWcOrderFromAddMetaBoxArg($object);
+    $value = $order->get_meta('myparcel_hs_code');
     echo '<label for="hs_code_input">HS code</label>';
     echo '<input type="text" name="hs_code_input" id="hs_code_input" value="' . $value . '">';
 }
 
-function saveMyparcelcomProductMeta(int $postId): void
+function saveMyparcelcomProductMeta(int $orderId): void
 {
+    $order = wc_get_order($orderId);
     if (array_key_exists('hs_code_input', $_POST)) {
-        update_post_meta($postId, 'myparcel_hs_code', $_POST['hs_code_input']);
+        $order->update_meta_data('myparcel_hs_code', $_POST['hs_code_input']);
     }
     if (array_key_exists('coo_input', $_POST)) {
-        update_post_meta($postId, 'myparcel_product_country', $_POST['coo_input']);
+        $order->update_meta_data('myparcel_product_country', $_POST['coo_input']);
     }
 }
 

--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -110,8 +110,6 @@ function bulkActionsEditProduct(array $actions): array
     return $actions;
 }
 
-// TODO: check that this still works without HPOS
-// add_filter('bulk_actions-edit-shop_order', 'bulkActionsEditProduct', 20, 1);
 add_filter('bulk_actions-woocommerce_page_wc-orders', 'bulkActionsEditProduct', 20, 1);
 
 /**
@@ -197,8 +195,6 @@ function myparcelcomBulkActionHandler(string $redirectTo, string $action, array 
     return $redirectTo;
 }
 
-// TODO: check that this still works without HPOS
-//add_filter('handle_bulk_actions-edit-shop_order', 'myparcelcomBulkActionHandler', 10, 3);
 add_filter('handle_bulk_actions-woocommerce_page_wc-orders', 'myparcelcomBulkActionHandler', 10, 3);
 
 set_transient('shipment-plugin-notice', 'alive', 3);

--- a/includes/myparcel-shipment-hooks.php
+++ b/includes/myparcel-shipment-hooks.php
@@ -38,7 +38,7 @@ function myparcelcomWebhookCallback(WP_REST_Request $request)
     }
 
     $order = wc_get_order((int) $shipmentData['attributes']['customer_reference'] ?? null);
-    $shipmentId = get_post_meta((int) $order?->get_id(), MYPARCEL_SHIPMENT_ID, true);
+    $shipmentId = $order->get_meta(MYPARCEL_SHIPMENT_ID);
 
     if ($shipmentId === $shipmentData['id']) {
         $order->update_meta_data(MYPARCEL_SHIPMENT_DATA, json_encode([

--- a/includes/myparcel-shipment-hooks.php
+++ b/includes/myparcel-shipment-hooks.php
@@ -41,7 +41,7 @@ function myparcelcomWebhookCallback(WP_REST_Request $request)
     $shipmentId = get_post_meta((int) $order?->get_id(), MYPARCEL_SHIPMENT_ID, true);
 
     if ($shipmentId === $shipmentData['id']) {
-        update_post_meta($order->get_id(), MYPARCEL_SHIPMENT_DATA, json_encode([
+        $order->update_meta_data(MYPARCEL_SHIPMENT_DATA, json_encode([
             'status_code'   => $statusData['attributes']['code'],
             'status_name'   => $statusData['attributes']['name'],
             'tracking_code' => $shipmentData['attributes']['tracking_code'] ?? null,

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -13,16 +13,25 @@ declare(strict_types=1);
  * Tested up to:
  * Requires PHP: 8.0
  * Requires Plugins: woocommerce
- * WC requires at least: 7.1
- * WC tested up to: 8.0
- * WC HPOS compatibility: yes
  *
  * @package WooCommerceConnectMyParcel
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
+
+// Declare HPOS compatibility.
+add_action('before_woocommerce_init', function() {
+    if (class_exists(FeaturesUtil::class)) {
+        FeaturesUtil::declare_compatibility(
+            'custom_order_tables',
+            __FILE__
+        );
+    }
+});
 
 require_once dirname(__FILE__) . '/vendor/autoload.php';
 require_once dirname(__FILE__) . '/includes/myparcel-api.php';

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
  * Tested up to:
  * Requires PHP: 8.0
  * Requires Plugins: woocommerce
+ * WC requires at least: 7.1
+ * WC tested up to: 8.0
+ * WC HPOS compatibility: yes
  *
  * @package WooCommerceConnectMyParcel
  */


### PR DESCRIPTION
## What changed
For this new storage feature to work: 
 - All access to order data (meta data, items etc..) needs to be done through the WooCommerce order class (`WC_Order`)
 - According to documentation I saw this should be backwards compatible so using the old storage feature (Wordress Posts) should still work.
 - Plugin decleration of support HPOS
 - Small adjustments to other names of functions that changes on WooCommerce