### PR TITLE
⏪️ Revert product meta functionality

### DIFF
--- a/includes/common/common-functions.php
+++ b/includes/common/common-functions.php
@@ -14,19 +14,6 @@ use MyParcelCom\ApiSdk\Resources\ShipmentItem;
 use MyParcelCom\ApiSdk\Resources\Shop;
 
 /**
- * Get the order (WC_Order) from the given argument of calling `add_meta_box`. The argument can be a WP_Post (WordPress class) or a WC_Order (Woocommerce class).
- * Src: https://stackoverflow.com/questions/78261367/add-a-custom-metabox-to-woocommerce-admin-orders-with-hpos-enabled
- * @param WC_Order|WP_Post $arg - the resource to get the order from.
- * @return WC_Order
- */
-function getWcOrderFromAddMetaBoxArg(WC_Order|WP_Post $arg): WC_Order
-{
-    return $arg instanceof WP_Post
-        ? wc_get_order($arg->ID)
-        : $arg;
-}
-
-/**
  * @return WC_Order_Item[]
  */
 function getOrderItemsByOrderId(int $orderId): array
@@ -69,8 +56,8 @@ function getShipmentItems($orderId, $currency, $originCountryCode): array
         $imageUrl = $product->get_image_id() ? wp_get_attachment_image_url($product->get_image_id(), 'medium') : null;
         $itemValue = (int) round(floatval($product->get_price()) * 100);
         $itemWeight = $product->get_weight() ? (int) round(floatval($product->get_weight()) * 1000) : null;
-        $hsCode = $order->get_meta('myparcel_hs_code') ?: null;
-        $productCountry = $order->get_meta('myparcel_product_country');
+        $hsCode = get_post_meta($product->get_id(), 'myparcel_hs_code', true) ?: null;
+        $productCountry = get_post_meta($product->get_id(), 'myparcel_product_country', true);
 
         $shipmentItems[] = (new ShipmentItem())
             ->setSku($sku)

--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -360,7 +360,7 @@ function isEUCountry(string $countryCode): bool
 /**
  * Add meta box input fields on the right side of the "product" edit page.
  */
-function addMyparcelcomProductMeta(WC_Order|WP_Post $object): void
+function addMyparcelcomProductMeta(WP_Post $post): void
 {
     add_meta_box('product_country', 'Country Of Origin', 'renderCountryOfOriginInput', 'product', 'side');
     add_meta_box('product_hs_code', 'HS code', 'renderHsCodeInput', 'product', 'side');
@@ -368,39 +368,37 @@ function addMyparcelcomProductMeta(WC_Order|WP_Post $object): void
 
 add_action('add_meta_boxes_product', 'addMyparcelcomProductMeta');
 
-
 /**
- * Render meta input field for Country Of Origin.
+ * Render product meta input field for Country Of Origin.
  */
-function renderCountryOfOriginInput(WC_Order|WP_Post $object): void
+function renderCountryOfOriginInput(WP_Post $post): void
 {
-    $order = getWcOrderFromAddMetaBoxArg($object);
-    $value = $order->get_meta('myparcel_product_country');
+    $value = get_post_meta($post->ID, 'myparcel_product_country', true);
     echo '<label for="coo_input">Country Of Origin</label>';
     echo '<input type="text" name="coo_input" id="coo_input" value="' . $value . '">';
 }
 
 /**
- * Render meta input field for HS code.
+ * Render product meta input field for HS code.
  */
-function renderHsCodeInput(WC_Order|WP_Post $object): void
+function renderHsCodeInput(WP_Post $post): void
 {
-    $order = getWcOrderFromAddMetaBoxArg($object);
-    $value = $order->get_meta('myparcel_hs_code');
+    $value = get_post_meta($post->ID, 'myparcel_hs_code', true);
     echo '<label for="hs_code_input">HS code</label>';
     echo '<input type="text" name="hs_code_input" id="hs_code_input" value="' . $value . '">';
 }
 
-function saveMyparcelcomProductMeta(int $orderId): void
+/**
+ * Make sure our meta fields are saved when a product is saved.
+ */
+function saveMyparcelcomProductMeta(int $postId): void
 {
-    $order = wc_get_order($orderId);
     if (array_key_exists('hs_code_input', $_POST)) {
-        $order->update_meta_data('myparcel_hs_code', $_POST['hs_code_input']);
+        update_post_meta($postId, 'myparcel_hs_code', $_POST['hs_code_input']);
     }
     if (array_key_exists('coo_input', $_POST)) {
-        $order->update_meta_data('myparcel_product_country', $_POST['coo_input']);
+        update_post_meta($postId, 'myparcel_product_country', $_POST['coo_input']);
     }
-    $order->save_meta_data();
 }
 
 add_action('save_post', 'saveMyparcelcomProductMeta');


### PR DESCRIPTION
Products are still a simple `WP_Post` and should not be treated as orders.